### PR TITLE
Add support for community auditors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM python:3-alpine
+FROM python:3-slim-buster
 
 COPY requirements.txt /requirements.txt
-RUN apk --no-cache add bash && \
-    pip --no-cache-dir install -r /requirements.txt
+RUN pip --no-cache-dir install -r /requirements.txt
 
 COPY iam-lint /iam-lint
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -67,6 +67,20 @@ testArgumentsPrivateAuditors() {
                 "[ $(echo ${OUTPUT} | grep -c "MEDIUM - Sensitive bucket access") -eq 1 ]"
 }
 
+testArgumentsCommunityAuditors() {
+    set -x
+    OUTPUT="$(docker run -e INPUT_COMMUNITY_AUDITORS=true \
+                         -v ${TEST_POLICY_DIR}/valid:/src \
+                         iam-lint /src)"
+    RC=$?
+
+    assertTrue "iam-lint exited with a different return code than expected: ${RC}" \
+                "[ ${RC} -eq 0 ]"
+    set +x
+    assertTrue "--include-community-auditors not in output" \
+                "[ $(echo ${OUTPUT} | grep -c -- "--include-community-auditors") -eq 1 ]"
+}
+
 #
 # Lint functionality tests
 #

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -68,7 +68,6 @@ testArgumentsPrivateAuditors() {
 }
 
 testArgumentsCommunityAuditors() {
-    set -x
     OUTPUT="$(docker run -e INPUT_COMMUNITY_AUDITORS=true \
                          -v ${TEST_POLICY_DIR}/valid:/src \
                          iam-lint /src)"
@@ -76,7 +75,6 @@ testArgumentsCommunityAuditors() {
 
     assertTrue "iam-lint exited with a different return code than expected: ${RC}" \
                 "[ ${RC} -eq 0 ]"
-    set +x
     assertTrue "--include-community-auditors not in output" \
                 "[ $(echo ${OUTPUT} | grep -c -- "--include-community-auditors") -eq 1 ]"
 }


### PR DESCRIPTION
Should be merged after duo-labs/parliament#90 is fixed.

Image changed because on Alpine Linux, I would need to compile policy_sentry dependencies and that adds additional build time.