### PR TITLE
fix: parliament now supports piping individual files via stdin

### DIFF
--- a/iam-lint
+++ b/iam-lint
@@ -65,7 +65,8 @@ while read -r file;
 do
     echo -n "==> Linting $file... "
 
-    OUTPUT="$(parliament "${PARLIAMENT_ARGS[@]}" --file "${file}" 2>&1 || true)"
+    OUTPUT=`cat "${file}" | parliament "${PARLIAMENT_ARGS[@]}" 2>&1 || true`
+
     if [[ -n "${OUTPUT}" ]]; then
         red "FAILED"
         echo "${OUTPUT}"


### PR DESCRIPTION
Update call to parliament to work with versions greater than 0.4.6.

Rather than using the --file keyword, use the pipe operator to pass the file via stdin. For some reason the command substitution is causing the parliament library to think there is a stdin being passed in and its throwing the below error

This fixed the error:
```bash
parliament: error: You cannot pass a file with --file and use stdin together
```

Will resolve the following [issue](https://github.com/xen0l/iam-lint/issues/7)